### PR TITLE
Support music as a first-class field

### DIFF
--- a/src/app/api/activities/[activityId]/__tests__/patchActivity.test.js
+++ b/src/app/api/activities/[activityId]/__tests__/patchActivity.test.js
@@ -1,12 +1,18 @@
 import { sql } from "@vercel/postgres";
-import patchActivity, { NoPatchableKeysError } from "../patchActivity";
+import patchActivity, { NoPatchableKeysError, InvalidLevelError } from "../patchActivity";
 
 describe("patchActivity", () => {
     beforeEach(() => {
         sql.query = jest.fn().mockResolvedValue();
     });
+    it("should throw an error if no valid permission level was provided", async () => {
+        await expect(() => patchActivity("1", { foo: "bar" }, 'boogers')).rejects.toThrow(
+            InvalidLevelError,
+        );
+    });
+
     it("should throw an error if no patchable keys are provided", async () => {
-        await expect(() => patchActivity("1", { foo: "bar" })).rejects.toThrow(
+        await expect(() => patchActivity("1", { foo: "bar" }, 'editor')).rejects.toThrow(
             NoPatchableKeysError,
         );
     });
@@ -17,14 +23,15 @@ describe("patchActivity", () => {
             foo: "bar",
             title: "boogers",
             description: "green things",
+            music: ['song1', 'song2'],
             sortIndex: 1,
             scheduleIndex: null,
         };
-        await patchActivity("1", activity);
+        await patchActivity("1", activity, 'editor');
 
         expect(sql.query).toHaveBeenCalledWith(
-            "UPDATE activities SET title = $1, description = $2, sortIndex = $3, scheduleIndex = $4 WHERE id = $5",
-            ["boogers", "green things", 1, null, "1"],
+            "UPDATE activities SET title = $1, description = $2, music = $3, sortIndex = $4, scheduleIndex = $5 WHERE id = $6",
+            ["boogers", "green things", '["song1","song2"]', 1, null, "1"],
         );
     });
 
@@ -32,11 +39,28 @@ describe("patchActivity", () => {
         const activity = {
             description: "green things",
         };
-        await patchActivity("1", activity);
+        await patchActivity("1", activity, 'editor');
 
         expect(sql.query).toHaveBeenCalledWith(
             "UPDATE activities SET description = $1 WHERE id = $2",
             ["green things", "1"],
+        );
+    });
+
+    it("should update the activity with the user patchable values and not the editor patchable values when permissionLevel is user", async () => {
+        const activity = {
+            id: "1",
+            title: "boogers",
+            description: "green things",
+            music: ['song1', 'song2'],
+            sortIndex: 1,
+            scheduleIndex: null,
+        };
+        await patchActivity("1", activity, 'user');
+
+        expect(sql.query).toHaveBeenCalledWith(
+            "UPDATE activities SET music = $1 WHERE id = $2",
+            ['["song1","song2"]', "1"],
         );
     });
 });

--- a/src/app/api/activities/[activityId]/__tests__/patchActivity.test.js
+++ b/src/app/api/activities/[activityId]/__tests__/patchActivity.test.js
@@ -1,20 +1,23 @@
 import { sql } from "@vercel/postgres";
-import patchActivity, { NoPatchableKeysError, InvalidLevelError } from "../patchActivity";
+import patchActivity, {
+    NoPatchableKeysError,
+    InvalidLevelError,
+} from "../patchActivity";
 
 describe("patchActivity", () => {
     beforeEach(() => {
         sql.query = jest.fn().mockResolvedValue();
     });
     it("should throw an error if no valid permission level was provided", async () => {
-        await expect(() => patchActivity("1", { foo: "bar" }, 'boogers')).rejects.toThrow(
-            InvalidLevelError,
-        );
+        await expect(() =>
+            patchActivity("1", { foo: "bar" }, "boogers"),
+        ).rejects.toThrow(InvalidLevelError);
     });
 
     it("should throw an error if no patchable keys are provided", async () => {
-        await expect(() => patchActivity("1", { foo: "bar" }, 'editor')).rejects.toThrow(
-            NoPatchableKeysError,
-        );
+        await expect(() =>
+            patchActivity("1", { foo: "bar" }, "editor"),
+        ).rejects.toThrow(NoPatchableKeysError);
     });
 
     it("should update the activity with the patchable values and not the non-patchable values", async () => {
@@ -23,11 +26,11 @@ describe("patchActivity", () => {
             foo: "bar",
             title: "boogers",
             description: "green things",
-            music: ['song1', 'song2'],
+            music: ["song1", "song2"],
             sortIndex: 1,
             scheduleIndex: null,
         };
-        await patchActivity("1", activity, 'editor');
+        await patchActivity("1", activity, "editor");
 
         expect(sql.query).toHaveBeenCalledWith(
             "UPDATE activities SET title = $1, description = $2, music = $3, sortIndex = $4, scheduleIndex = $5 WHERE id = $6",
@@ -39,7 +42,7 @@ describe("patchActivity", () => {
         const activity = {
             description: "green things",
         };
-        await patchActivity("1", activity, 'editor');
+        await patchActivity("1", activity, "editor");
 
         expect(sql.query).toHaveBeenCalledWith(
             "UPDATE activities SET description = $1 WHERE id = $2",
@@ -52,11 +55,11 @@ describe("patchActivity", () => {
             id: "1",
             title: "boogers",
             description: "green things",
-            music: ['song1', 'song2'],
+            music: ["song1", "song2"],
             sortIndex: 1,
             scheduleIndex: null,
         };
-        await patchActivity("1", activity, 'user');
+        await patchActivity("1", activity, "user");
 
         expect(sql.query).toHaveBeenCalledWith(
             "UPDATE activities SET music = $1 WHERE id = $2",

--- a/src/app/api/activities/[activityId]/__tests__/route.test.js
+++ b/src/app/api/activities/[activityId]/__tests__/route.test.js
@@ -155,7 +155,7 @@ describe("activities/activityId/route", () => {
                     activity: { foo: "bar" },
                 }),
             };
-            const response = await PATCH(mockReq, {
+            await PATCH(mockReq, {
                 params: { activityId: "1" },
             });
             expect(patchActivity).toHaveBeenCalledWith("1", { foo: "bar" }, 'user');

--- a/src/app/api/activities/[activityId]/__tests__/route.test.js
+++ b/src/app/api/activities/[activityId]/__tests__/route.test.js
@@ -16,7 +16,7 @@ jest.mock("next/headers");
 describe("activities/activityId/route", () => {
     let mockGetCookie;
     beforeEach(() => {
-        validatePasscode.mockResolvedValue();
+        validatePasscode.mockResolvedValue(true);
         mockGetCookie = jest.fn().mockReturnValue({
             value: "boogers",
         });
@@ -143,9 +143,22 @@ describe("activities/activityId/route", () => {
             const response = await PATCH(mockReq, {
                 params: { activityId: "1" },
             });
-            expect(patchActivity).toHaveBeenCalledWith("1", { foo: "bar" });
+            expect(patchActivity).toHaveBeenCalledWith("1", { foo: "bar" }, 'editor');
             expect(logUpdateByTableName).toHaveBeenCalledWith("activities");
             expect(response).toEqual({ data: {} });
+        });
+        it('sends "user" permissionLevel if the user is a user and not an editor', async () => {
+            validatePasscode.mockRejectedValueOnce(new InvalidPasscodeError());
+            validatePasscode.mockResolvedValueOnce(true);
+            const mockReq = {
+                json: jest.fn().mockResolvedValue({
+                    activity: { foo: "bar" },
+                }),
+            };
+            const response = await PATCH(mockReq, {
+                params: { activityId: "1" },
+            });
+            expect(patchActivity).toHaveBeenCalledWith("1", { foo: "bar" }, 'user');
         });
     });
 });

--- a/src/app/api/activities/[activityId]/__tests__/route.test.js
+++ b/src/app/api/activities/[activityId]/__tests__/route.test.js
@@ -143,7 +143,11 @@ describe("activities/activityId/route", () => {
             const response = await PATCH(mockReq, {
                 params: { activityId: "1" },
             });
-            expect(patchActivity).toHaveBeenCalledWith("1", { foo: "bar" }, 'editor');
+            expect(patchActivity).toHaveBeenCalledWith(
+                "1",
+                { foo: "bar" },
+                "editor",
+            );
             expect(logUpdateByTableName).toHaveBeenCalledWith("activities");
             expect(response).toEqual({ data: {} });
         });
@@ -158,7 +162,11 @@ describe("activities/activityId/route", () => {
             await PATCH(mockReq, {
                 params: { activityId: "1" },
             });
-            expect(patchActivity).toHaveBeenCalledWith("1", { foo: "bar" }, 'user');
+            expect(patchActivity).toHaveBeenCalledWith(
+                "1",
+                { foo: "bar" },
+                "user",
+            );
         });
     });
 });

--- a/src/app/api/activities/[activityId]/patchActivity.js
+++ b/src/app/api/activities/[activityId]/patchActivity.js
@@ -38,7 +38,7 @@ export default async function patchActivity(
 
     if (!patchableKeysByLevel[permissionLevel]?.length) {
         throw new InvalidLevelError();
-    };
+    }
 
     const setStrings = patchableKeysByLevel[permissionLevel].reduce(
         (acc, key) => {

--- a/src/app/api/activities/[activityId]/patchActivity.js
+++ b/src/app/api/activities/[activityId]/patchActivity.js
@@ -8,30 +8,50 @@ export class NoPatchableKeysError extends Error {
     }
 }
 
+export class InvalidLevelError extends Error {
+    constructor(message) {
+        super(message);
+        this.name = "InvalidLevelError";
+        this.message = "No valid permission level was provided";
+    }
+}
+
 /**
  * Patch an existing activity with new values.
  *
  * @param {string} activityId
  * @param {Partial<Activity>} activity
+ * @param {string} permissionLevel Options: "editor", "user"
  * @returns {Promise<void>}
  * @throws {NoPatchableKeysError} If no patchable keys were provided.
+ * @throws {InvalidLevelError} If an invalid permissionLevel was provided
  */
-export default async function patchActivity(activityId, activity) {
-    const patchableKeys = [
-        "title",
-        "description",
-        "sortIndex",
-        "scheduleIndex",
-    ];
+export default async function patchActivity(
+    activityId,
+    activity,
+    permissionLevel,
+) {
+    const patchableKeysByLevel = {
+        editor: ["title", "description", "music", "sortIndex", "scheduleIndex"],
+        user: ["music"],
+    };
 
-    const setStrings = patchableKeys.reduce(
+    if (!patchableKeysByLevel[permissionLevel]?.length) {
+        throw new InvalidLevelError();
+    };
+
+    const setStrings = patchableKeysByLevel[permissionLevel].reduce(
         (acc, key) => {
             if (!Object.hasOwn(activity, key)) {
                 return acc;
             }
+            let value = activity[key];
+            if (key === "music") {
+                value = JSON.stringify(value);
+            }
             return {
                 query: `${acc.query}${acc.values.length ? ", " : ""}${key} = $${acc.values.length + 1}`,
-                values: [...acc.values, activity[key]],
+                values: [...acc.values, value],
             };
         },
         {

--- a/src/app/api/activities/__tests__/route.test.js
+++ b/src/app/api/activities/__tests__/route.test.js
@@ -47,7 +47,7 @@ describe("activities/route", () => {
                             id: "1",
                             title: "boogers",
                             description: "green things",
-                            music: ['song1', 'song2'],
+                            music: ["song1", "song2"],
                             sortIndex: 1,
                             scheduleIndex: null,
                         },
@@ -131,7 +131,7 @@ describe("activities/route", () => {
                 expect.anything(),
                 "boogers",
                 "green things",
-                "[\"song1\",\"song2\"]",
+                '["song1","song2"]',
                 0,
             );
         });
@@ -158,7 +158,7 @@ describe("activities/route", () => {
                 expect.anything(),
                 "boogers",
                 "green things",
-                "[\"song1\",\"song2\"]",
+                '["song1","song2"]',
                 6,
             );
         });
@@ -214,14 +214,22 @@ describe("activities/route", () => {
             };
             await PATCH(mockReq);
             expect(patchActivity).toHaveBeenCalledTimes(2);
-            expect(patchActivity).toHaveBeenCalledWith("1", {
-                id: "1",
-                description: "test",
-            }, 'editor');
-            expect(patchActivity).toHaveBeenCalledWith("2", {
-                id: "2",
-                sortIndex: 2,
-            }, 'editor');
+            expect(patchActivity).toHaveBeenCalledWith(
+                "1",
+                {
+                    id: "1",
+                    description: "test",
+                },
+                "editor",
+            );
+            expect(patchActivity).toHaveBeenCalledWith(
+                "2",
+                {
+                    id: "2",
+                    sortIndex: 2,
+                },
+                "editor",
+            );
             expect(logUpdateByTableName).toHaveBeenCalledWith("activities");
         });
     });

--- a/src/app/api/activities/__tests__/route.test.js
+++ b/src/app/api/activities/__tests__/route.test.js
@@ -33,6 +33,7 @@ describe("activities/route", () => {
                         id: "1",
                         title: "boogers",
                         description: "green things",
+                        music: '["song1","song2"]',
                         sortindex: 1,
                         scheduleindex: null,
                     },
@@ -46,6 +47,7 @@ describe("activities/route", () => {
                             id: "1",
                             title: "boogers",
                             description: "green things",
+                            music: ['song1', 'song2'],
                             sortIndex: 1,
                             scheduleIndex: null,
                         },
@@ -113,12 +115,14 @@ describe("activities/route", () => {
                 json: jest.fn().mockResolvedValue({
                     title: "boogers",
                     description: "green things",
+                    music: ["song1", "song2"],
                 }),
             };
             await POST(mockReq);
             expect(sql).toHaveBeenCalledWith(
                 [
-                    "INSERT INTO activities (id, title, description, sortIndex, scheduleIndex) VALUES (",
+                    "INSERT INTO activities (id, title, description, music, sortIndex, scheduleIndex) VALUES (",
+                    ", ",
                     ", ",
                     ", ",
                     ", ",
@@ -127,6 +131,7 @@ describe("activities/route", () => {
                 expect.anything(),
                 "boogers",
                 "green things",
+                "[\"song1\",\"song2\"]",
                 0,
             );
         });
@@ -137,12 +142,14 @@ describe("activities/route", () => {
                 json: jest.fn().mockResolvedValue({
                     title: "boogers",
                     description: "green things",
+                    music: ["song1", "song2"],
                 }),
             };
             await POST(mockReq);
             expect(sql).toHaveBeenCalledWith(
                 [
-                    "INSERT INTO activities (id, title, description, sortIndex, scheduleIndex) VALUES (",
+                    "INSERT INTO activities (id, title, description, music, sortIndex, scheduleIndex) VALUES (",
+                    ", ",
                     ", ",
                     ", ",
                     ", ",
@@ -151,13 +158,14 @@ describe("activities/route", () => {
                 expect.anything(),
                 "boogers",
                 "green things",
+                "[\"song1\",\"song2\"]",
                 6,
             );
         });
     });
     describe("PATCH", () => {
         beforeEach(() => {
-            validatePasscode.mockResolvedValue();
+            validatePasscode.mockResolvedValue(true);
             patchActivity.mockResolvedValue();
         });
         it("should return a 400 if no passcode was provided", async () => {
@@ -177,7 +185,7 @@ describe("activities/route", () => {
                 status: 401,
             });
         });
-        it("should return a 403 if the provided passcode does not match the editor passcode", async () => {
+        it("should return a 403 if the provided passcode does not match the editor or user passcode", async () => {
             mockGetCookie.mockReturnValue({ value: "boogers" });
             validatePasscode.mockRejectedValue(new InvalidPasscodeError());
             const mockReq = {
@@ -209,11 +217,11 @@ describe("activities/route", () => {
             expect(patchActivity).toHaveBeenCalledWith("1", {
                 id: "1",
                 description: "test",
-            });
+            }, 'editor');
             expect(patchActivity).toHaveBeenCalledWith("2", {
                 id: "2",
                 sortIndex: 2,
-            });
+            }, 'editor');
             expect(logUpdateByTableName).toHaveBeenCalledWith("activities");
         });
     });

--- a/src/app/api/passcodes/validatePasscode.js
+++ b/src/app/api/passcodes/validatePasscode.js
@@ -16,6 +16,12 @@ export class InvalidPasscodeError extends Error {
     }
 }
 
+/**
+ *
+ * @param {String} passcode
+ * @param {String[]} levels Options: "admin", "editor", "user"
+ * @returns true if passcode matches levels
+ */
 export default async function validatePasscode(passcode, levels) {
     if (!passcode) {
         throw new NoPasscodeError();

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -6,15 +6,25 @@ export default async function Home() {
     const activitiesResponse =
         await sql`SELECT * FROM activities ORDER BY scheduleIndex ASC, sortIndex ASC`;
     const activities = activitiesResponse.rows.map((activity) => {
-        const { id, title, description, sortindex, scheduleindex } = activity;
+        const { id, title, description, sortindex, scheduleindex, music } =
+            activity;
         return {
             id,
             title,
             description,
+            music: parseMusic(music),
             sortIndex: sortindex,
             scheduleIndex: scheduleindex,
         };
     });
 
     return <HomePage activities={activities} />;
+}
+
+function parseMusic(music) {
+    try {
+        return JSON.parse(music);
+    } catch (error) {
+        return [music];
+    }
 }

--- a/src/components/ActivitiesContainer.js
+++ b/src/components/ActivitiesContainer.js
@@ -195,13 +195,13 @@ const ActivitiesContainer = ({ children, initialActivities }) => {
         scheduledActivities: activitiesData.scheduledActivities,
         unscheduledActivities: activitiesData.unscheduledActivities,
         isLoading,
-        createActivity: async ({ title, description }) => {
+        createActivity: async ({ title, description, music }) => {
             const response = await fetch("/api/activities", {
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",
                 },
-                body: JSON.stringify({ title, description }),
+                body: JSON.stringify({ title, description, music }),
             });
             if (!response.ok) {
                 openAlert("Failed to create activity", "error");

--- a/src/components/ActivityDisplay.js
+++ b/src/components/ActivityDisplay.js
@@ -16,7 +16,7 @@ import Button from "./ui/Button";
 import ActivityMusicForm from "./ActivityMusicForm";
 
 function isMusicMissing(music) {
-    return !!(!music?.length || music.every((m) => !m.trim()))
+    return !!(!music?.length || music.every((m) => !m.trim()));
 }
 
 const ActivityDisplay = ({

--- a/src/components/ActivityMusicForm.js
+++ b/src/components/ActivityMusicForm.js
@@ -1,45 +1,29 @@
 "use client";
 
 import { useState } from "react";
-import { useAuth } from "./global/Auth";
 import Panel from "./ui/Panel";
-import TextInput from "./ui/TextInput";
-import Textarea from "./ui/Textarea";
 import Button from "./ui/Button";
 import H1 from "./ui/H1";
 import { css } from "../../styled-system/css";
 import TextInputList from "./ui/TextInputList";
 
-const ActivityForm = ({
-    isEdit = false,
+const ActivityMusicForm = ({
     onSubmit,
-    title: defaultTitle = "",
-    description: defaultDescription = "",
     music: defaultMusic = [],
     onCancel,
-    autoFocus = false,
 }) => {
-    const { isEditor } = useAuth();
     const [pending, setPending] = useState(false);
-    const [title, setTitle] = useState(defaultTitle);
-    const [description, setDescription] = useState(defaultDescription);
     const [music, setMusic] = useState(defaultMusic);
-
-    if (!isEditor()) {
-        return null;
-    }
 
     async function submit() {
         setPending(true);
-        await onSubmit({ title, description, music });
-        setTitle(defaultTitle);
-        setDescription(defaultDescription);
-        setPending(false);
+        await onSubmit({ music });
         setMusic([]);
+        setPending(false);
     }
     return (
         <form
-            data-testid="create-activity-form"
+            data-testid="activity-music-form"
             onSubmit={(e) => {
                 e.preventDefault();
                 submit();
@@ -52,23 +36,9 @@ const ActivityForm = ({
                     fontSize: { base: "20px", sm: "24px" },
                 })}
             >
-                {isEdit ? "Edit Activity" : "Create Activity"}
+                Edit Music
             </H1>
             <Panel>
-                <label>Title (required)</label>
-                <TextInput
-                    autoFocus={autoFocus}
-                    data-testid="title"
-                    required
-                    value={title}
-                    onChange={(e) => setTitle(e.target.value)}
-                />
-                <label>Description</label>
-                <Textarea
-                    data-testid="description"
-                    value={description}
-                    onChange={(e) => setDescription(e.target.value)}
-                />
                 <label>Music</label>
                 <TextInputList
                     value={music}
@@ -95,4 +65,4 @@ const ActivityForm = ({
     );
 };
 
-export default ActivityForm;
+export default ActivityMusicForm;

--- a/src/components/__tests__/ActivitiesContainer.test.js
+++ b/src/components/__tests__/ActivitiesContainer.test.js
@@ -213,6 +213,7 @@ describe("ActivitiesContainer", () => {
                                     createActivity({
                                         title: "Activity 5",
                                         description: "Description 5",
+                                        music: ['song1', 'song2']
                                     })
                                 }
                             >
@@ -235,6 +236,7 @@ describe("ActivitiesContainer", () => {
                 body: JSON.stringify({
                     title: "Activity 5",
                     description: "Description 5",
+                    music: ['song1', 'song2']
                 }),
             });
 

--- a/src/components/__tests__/ActivitiesContainer.test.js
+++ b/src/components/__tests__/ActivitiesContainer.test.js
@@ -213,7 +213,7 @@ describe("ActivitiesContainer", () => {
                                     createActivity({
                                         title: "Activity 5",
                                         description: "Description 5",
-                                        music: ['song1', 'song2']
+                                        music: ["song1", "song2"],
                                     })
                                 }
                             >
@@ -236,7 +236,7 @@ describe("ActivitiesContainer", () => {
                 body: JSON.stringify({
                     title: "Activity 5",
                     description: "Description 5",
-                    music: ['song1', 'song2']
+                    music: ["song1", "song2"],
                 }),
             });
 

--- a/src/components/__tests__/ActivityDisplay.test.js
+++ b/src/components/__tests__/ActivityDisplay.test.js
@@ -29,7 +29,7 @@ describe("ActivityDisplay", () => {
         });
         useAuth.mockReturnValue({
             isEditor: jest.fn().mockReturnValue(false),
-            isPublic: jest.fn().mockReturnValue(true)
+            isPublic: jest.fn().mockReturnValue(true),
         });
     });
     it("renders activity title", async () => {
@@ -128,11 +128,11 @@ describe("ActivityDisplay", () => {
         expect(screen.queryByTestId("show-less")).not.toBeInTheDocument();
     });
 
-    describe('editor', () => {
+    describe("editor", () => {
         beforeEach(() => {
             useAuth.mockReturnValue({
                 isEditor: jest.fn().mockReturnValue(true),
-                isPublic: jest.fn().mockReturnValue(false)
+                isPublic: jest.fn().mockReturnValue(false),
             });
         });
         it("allows an editor to delete an activity", async () => {
@@ -143,7 +143,9 @@ describe("ActivityDisplay", () => {
                 });
             });
             mockOpenPrompt.mockResolvedValue();
-            render(<ActivityDisplay activity={mockActivity} onDelete={onDelete} />);
+            render(
+                <ActivityDisplay activity={mockActivity} onDelete={onDelete} />,
+            );
 
             await userEvent.click(screen.getByTestId("activity-dropdown"));
             await userEvent.click(screen.getByTestId("delete-activity"));
@@ -158,9 +160,9 @@ describe("ActivityDisplay", () => {
             );
             resolveDelete();
             await waitFor(() =>
-                expect(screen.getByTestId("delete-activity")).not.toHaveAttribute(
-                    "disabled",
-                ),
+                expect(
+                    screen.getByTestId("delete-activity"),
+                ).not.toHaveAttribute("disabled"),
             );
         });
         it("allows an editor to edit an activity", async () => {
@@ -191,14 +193,19 @@ describe("ActivityDisplay", () => {
             });
             mockOpenPrompt.mockResolvedValue();
             render(
-                <ActivityDisplay activity={mockActivity} onSchedule={onSchedule} />,
+                <ActivityDisplay
+                    activity={mockActivity}
+                    onSchedule={onSchedule}
+                />,
             );
 
             await userEvent.click(screen.getByTestId("activity-dropdown"));
             await userEvent.click(screen.getByTestId("add-schedule"));
 
             expect(onSchedule).toHaveBeenCalledWith(mockActivity.id);
-            expect(screen.getByTestId("add-schedule")).toHaveAttribute("disabled");
+            expect(screen.getByTestId("add-schedule")).toHaveAttribute(
+                "disabled",
+            );
             resolveSchedule();
             await waitFor(() =>
                 expect(screen.getByTestId("add-schedule")).not.toHaveAttribute(
@@ -229,9 +236,9 @@ describe("ActivityDisplay", () => {
             );
             resolveUnschedule();
             await waitFor(() =>
-                expect(screen.getByTestId("remove-schedule")).not.toHaveAttribute(
-                    "disabled",
-                ),
+                expect(
+                    screen.getByTestId("remove-schedule"),
+                ).not.toHaveAttribute("disabled"),
             );
         });
         it("allows an editor to move an activity up", async () => {
@@ -241,7 +248,9 @@ describe("ActivityDisplay", () => {
                     doResolve = resolve;
                 });
             });
-            render(<ActivityDisplay activity={mockActivity} onMoveUp={onMoveUp} />);
+            render(
+                <ActivityDisplay activity={mockActivity} onMoveUp={onMoveUp} />,
+            );
 
             await userEvent.click(screen.getByTestId("activity-dropdown"));
             await userEvent.click(screen.getByTestId("move-up"));
@@ -263,7 +272,10 @@ describe("ActivityDisplay", () => {
                 });
             });
             render(
-                <ActivityDisplay activity={mockActivity} onMoveDown={onMoveDown} />,
+                <ActivityDisplay
+                    activity={mockActivity}
+                    onMoveDown={onMoveDown}
+                />,
             );
 
             await userEvent.click(screen.getByTestId("activity-dropdown"));
@@ -278,7 +290,7 @@ describe("ActivityDisplay", () => {
                 ),
             );
         });
-        
+
         it("allows an editor to edit music", async () => {
             const onEdit = jest.fn().mockImplementation(() => {
                 return Promise.resolve();
@@ -309,37 +321,49 @@ describe("ActivityDisplay", () => {
             });
             it("displays the position number of the scheduled activity, starting at 1", async () => {
                 render(
-                    <ActivityDisplay activity={mockActivity} onMoveTo={onMoveTo} />,
+                    <ActivityDisplay
+                        activity={mockActivity}
+                        onMoveTo={onMoveTo}
+                    />,
                 );
-    
+
                 expect(screen.getByTestId("schedule-index")).toHaveValue("1");
             });
             it("does not display the position number if the activity is not scheduled", async () => {
                 mockActivity.scheduleIndex = null;
-    
+
                 render(
-                    <ActivityDisplay activity={mockActivity} onMoveTo={onMoveTo} />,
+                    <ActivityDisplay
+                        activity={mockActivity}
+                        onMoveTo={onMoveTo}
+                    />,
                 );
-    
+
                 expect(screen.queryByTestId("schedule-index")).toBeNull();
             });
             it("does not display the user is not an editor", async () => {
                 useAuth.mockReturnValue({
                     isEditor: jest.fn().mockReturnValue(false),
-                    isPublic: jest.fn().mockReturnValue(true)
+                    isPublic: jest.fn().mockReturnValue(true),
                 });
-    
+
                 render(
-                    <ActivityDisplay activity={mockActivity} onMoveTo={onMoveTo} />,
+                    <ActivityDisplay
+                        activity={mockActivity}
+                        onMoveTo={onMoveTo}
+                    />,
                 );
-    
+
                 expect(screen.queryByTestId("schedule-index")).toBeNull();
             });
             it("updates the scheduleIndex when the number is changed", async () => {
                 render(
-                    <ActivityDisplay activity={mockActivity} onMoveTo={onMoveTo} />,
+                    <ActivityDisplay
+                        activity={mockActivity}
+                        onMoveTo={onMoveTo}
+                    />,
                 );
-    
+
                 await userEvent.click(screen.getByTestId("schedule-index"));
                 await userEvent.clear(screen.getByTestId("schedule-index"));
                 await userEvent.type(screen.getByTestId("schedule-index"), "2");
@@ -347,11 +371,14 @@ describe("ActivityDisplay", () => {
             });
             it("updates the scheduleIndex with the new value - 1 when moving up the schedule", async () => {
                 mockActivity.scheduleIndex = 5;
-    
+
                 render(
-                    <ActivityDisplay activity={mockActivity} onMoveTo={onMoveTo} />,
+                    <ActivityDisplay
+                        activity={mockActivity}
+                        onMoveTo={onMoveTo}
+                    />,
                 );
-    
+
                 await userEvent.click(screen.getByTestId("schedule-index"));
                 await userEvent.clear(screen.getByTestId("schedule-index"));
                 await userEvent.type(screen.getByTestId("schedule-index"), "2");
@@ -360,13 +387,13 @@ describe("ActivityDisplay", () => {
         });
     });
 
-    describe('user', () => {
+    describe("user", () => {
         beforeEach(() => {
             useAuth.mockReturnValue({
                 isEditor: jest.fn().mockReturnValue(false),
-                isPublic: jest.fn().mockReturnValue(false)
+                isPublic: jest.fn().mockReturnValue(false),
             });
-        })
+        });
         it("does not display the dropdown if the user is a user", async () => {
             render(<ActivityDisplay activity={mockActivity} />);
 
@@ -394,11 +421,11 @@ describe("ActivityDisplay", () => {
         });
     });
 
-    describe('public', () => {
+    describe("public", () => {
         beforeEach(() => {
             useAuth.mockReturnValue({
                 isEditor: jest.fn().mockReturnValue(false),
-                isPublic: jest.fn().mockReturnValue(true)
+                isPublic: jest.fn().mockReturnValue(true),
             });
         });
         it("does not display the dropdown if the user is general public", async () => {
@@ -416,10 +443,10 @@ describe("ActivityDisplay", () => {
             mockOpenPrompt.mockResolvedValue();
             render(<ActivityDisplay activity={mockActivity} onEdit={onEdit} />);
 
+            expect(screen.queryByTestId("edit-music")).not.toBeInTheDocument();
             expect(
-                screen.queryByTestId("edit-music"),
+                screen.queryByTestId("activity-music"),
             ).not.toBeInTheDocument();
-            expect(screen.queryByTestId("activity-music")).not.toBeInTheDocument();
         });
-    })
+    });
 });

--- a/src/components/__tests__/ActivityForm.test.js
+++ b/src/components/__tests__/ActivityForm.test.js
@@ -33,7 +33,7 @@ describe("ActivityForm", () => {
         expect(onSubmit).toHaveBeenCalledWith({
             title: "Cool Activity",
             description: "This is a cool activity",
-            music: ['song 1'],
+            music: ["song 1"],
         });
     });
     it("disables the save button while pending", async () => {
@@ -83,15 +83,15 @@ describe("ActivityForm", () => {
         expect(screen.getByTestId("description")).toHaveValue("");
         expect(screen.queryByTestId("input-item-0")).not.toBeInTheDocument();
     });
-    it('Uses the edit title if isEdit is true', async () => {
+    it("Uses the edit title if isEdit is true", async () => {
         useAuth.mockReturnValue({
             isEditor: jest.fn().mockReturnValue(true),
         });
         const onSubmit = jest.fn().mockResolvedValue();
         render(<ActivityForm onSubmit={onSubmit} />);
         expect(screen.getByText("Create Activity")).toBeInTheDocument();
-        
+
         render(<ActivityForm onSubmit={onSubmit} isEdit={true} />);
         expect(screen.getByText("Edit Activity")).toBeInTheDocument();
-    })
+    });
 });

--- a/src/components/__tests__/ActivityForm.test.js
+++ b/src/components/__tests__/ActivityForm.test.js
@@ -26,11 +26,14 @@ describe("ActivityForm", () => {
             screen.getByTestId("description"),
             "This is a cool activity",
         );
+        await userEvent.click(screen.getByTestId("add-item"));
+        await userEvent.type(screen.getByTestId("input-item-0"), "song 1");
         await userEvent.click(screen.getByTestId("save-activity"));
 
         expect(onSubmit).toHaveBeenCalledWith({
             title: "Cool Activity",
             description: "This is a cool activity",
+            music: ['song 1'],
         });
     });
     it("disables the save button while pending", async () => {
@@ -50,6 +53,8 @@ describe("ActivityForm", () => {
             screen.getByTestId("description"),
             "This is a cool activity",
         );
+        await userEvent.click(screen.getByTestId("add-item"));
+        await userEvent.type(screen.getByTestId("input-item-0"), "song 1");
         await userEvent.click(screen.getByTestId("save-activity"));
 
         expect(screen.getByTestId("save-activity")).toHaveAttribute("disabled");
@@ -76,5 +81,17 @@ describe("ActivityForm", () => {
 
         expect(screen.getByTestId("title")).toHaveValue("");
         expect(screen.getByTestId("description")).toHaveValue("");
+        expect(screen.queryByTestId("input-item-0")).not.toBeInTheDocument();
     });
+    it('Uses the edit title if isEdit is true', async () => {
+        useAuth.mockReturnValue({
+            isEditor: jest.fn().mockReturnValue(true),
+        });
+        const onSubmit = jest.fn().mockResolvedValue();
+        render(<ActivityForm onSubmit={onSubmit} />);
+        expect(screen.getByText("Create Activity")).toBeInTheDocument();
+        
+        render(<ActivityForm onSubmit={onSubmit} isEdit={true} />);
+        expect(screen.getByText("Edit Activity")).toBeInTheDocument();
+    })
 });

--- a/src/components/__tests__/ActivityMusicForm.test.js
+++ b/src/components/__tests__/ActivityMusicForm.test.js
@@ -1,0 +1,42 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { useAuth } from "../global/Auth";
+import ActivityMusicForm from "../ActivityMusicForm";
+import userEvent from "@testing-library/user-event";
+
+jest.mock("../global/Auth");
+
+describe("ActivityMusicForm", () => {
+    it("allows adding music", async () => {
+        const onSubmit = jest.fn().mockResolvedValue();
+        render(<ActivityMusicForm onSubmit={onSubmit} />);
+
+        await userEvent.click(screen.getByTestId("add-item"));
+        await userEvent.type(screen.getByTestId("input-item-0"), "song 1");
+        await userEvent.click(screen.getByTestId("save-activity"));
+
+        expect(onSubmit).toHaveBeenCalledWith({
+            music: ['song 1'],
+        });
+    });
+    it("disables the save button while pending", async () => {
+        let resolveSubmit;
+        const onSubmit = jest.fn().mockImplementation(() => {
+            return new Promise((resolve) => {
+                resolveSubmit = resolve;
+            });
+        });
+        render(<ActivityMusicForm onSubmit={onSubmit} />);
+
+        await userEvent.click(screen.getByTestId("add-item"));
+        await userEvent.type(screen.getByTestId("input-item-0"), "song 1");
+        await userEvent.click(screen.getByTestId("save-activity"));
+
+        expect(screen.getByTestId("save-activity")).toHaveAttribute("disabled");
+        resolveSubmit();
+        await waitFor(() =>
+            expect(screen.getByTestId("save-activity")).not.toHaveAttribute(
+                "disabled",
+            ),
+        );
+    });
+});

--- a/src/components/__tests__/ActivityMusicForm.test.js
+++ b/src/components/__tests__/ActivityMusicForm.test.js
@@ -14,7 +14,7 @@ describe("ActivityMusicForm", () => {
         await userEvent.click(screen.getByTestId("save-activity"));
 
         expect(onSubmit).toHaveBeenCalledWith({
-            music: ['song 1'],
+            music: ["song 1"],
         });
     });
     it("disables the save button while pending", async () => {

--- a/src/components/__tests__/ActivityMusicForm.test.js
+++ b/src/components/__tests__/ActivityMusicForm.test.js
@@ -1,5 +1,4 @@
 import { render, screen, waitFor } from "@testing-library/react";
-import { useAuth } from "../global/Auth";
 import ActivityMusicForm from "../ActivityMusicForm";
 import userEvent from "@testing-library/user-event";
 

--- a/src/components/ui/Dropdown.js
+++ b/src/components/ui/Dropdown.js
@@ -57,12 +57,6 @@ const Dropdown = ({ children, dropdownContent, ...props }) => {
                         zIndex: "100",
                         minWidth: { base: "200px", sm: "auto" },
                         maxWidth: { base: "90vw", sm: "none" },
-                        // Prevent dropdown from going off-screen on mobile
-                        "@media (max-width: 640px)": {
-                            right: "auto",
-                            left: "50%",
-                            transform: "translateX(-50%)",
-                        },
                     })}
                 >
                     {dropdownContent(renderData)}

--- a/src/components/ui/TextInputList.js
+++ b/src/components/ui/TextInputList.js
@@ -65,12 +65,20 @@ const TextInputList = ({ value = [], onChange, ...props }) => {
                         onChange={(e) => handleChange(e.target.value, index)}
                     />
                     {index !== 0 && (
-                        <Button type="button" data-testid={`move-up-item-${index}`} onClick={() => moveUp(index)}>
+                        <Button
+                            type="button"
+                            data-testid={`move-up-item-${index}`}
+                            onClick={() => moveUp(index)}
+                        >
                             <i className="fa-solid fa-arrow-up" />
                         </Button>
                     )}
                     {index !== value.length - 1 && (
-                        <Button type="button" data-testid={`move-down-item-${index}`} onClick={() => moveDown(index)}>
+                        <Button
+                            type="button"
+                            data-testid={`move-down-item-${index}`}
+                            onClick={() => moveDown(index)}
+                        >
                             <i className="fa-solid fa-arrow-down" />
                         </Button>
                     )}

--- a/src/components/ui/TextInputList.js
+++ b/src/components/ui/TextInputList.js
@@ -1,0 +1,100 @@
+import { css } from "../../../styled-system/css";
+
+import Button from "./Button";
+import { usePrompt } from "./Prompt";
+import TextInput from "./TextInput";
+
+const TextInputList = ({ value = [], onChange, ...props }) => {
+    const { openPrompt } = usePrompt();
+
+    function handleChange(singleValue, index) {
+        const newValue = [...value];
+        newValue[index] = singleValue;
+        onChange(newValue);
+    }
+
+    async function handleRemove(index) {
+        if (value[index].trim() !== "") {
+            try {
+                await openPrompt(
+                    "Are you sure you want to remove this item?",
+                    "confirm",
+                );
+            } catch {
+                return;
+            }
+        }
+        const newValue = [...value];
+        newValue.splice(index, 1);
+        onChange(newValue);
+    }
+
+    function moveUp(index) {
+        const newValue = [...value];
+        const temp = newValue[index];
+        newValue[index] = newValue[index - 1];
+        newValue[index - 1] = temp;
+        onChange(newValue);
+    }
+
+    function moveDown(index) {
+        const newValue = [...value];
+        const temp = newValue[index];
+        newValue[index] = newValue[index + 1];
+        newValue[index + 1] = temp;
+        onChange(newValue);
+    }
+
+    return (
+        <ol {...props}>
+            {value.map((item, index) => (
+                <li
+                    key={index}
+                    className={css({
+                        display: "flex",
+                        alignItems: "center",
+                    })}
+                >
+                    <p className={css({ width: "25px", marginRight: "8px" })}>
+                        {index + 1}.
+                    </p>
+                    <TextInput
+                        data-testid={`input-item-${index}`}
+                        type="text"
+                        value={item}
+                        onChange={(e) => handleChange(e.target.value, index)}
+                    />
+                    {index !== 0 && (
+                        <Button type="button" data-testid={`move-up-item-${index}`} onClick={() => moveUp(index)}>
+                            <i className="fa-solid fa-arrow-up" />
+                        </Button>
+                    )}
+                    {index !== value.length - 1 && (
+                        <Button type="button" data-testid={`move-down-item-${index}`} onClick={() => moveDown(index)}>
+                            <i className="fa-solid fa-arrow-down" />
+                        </Button>
+                    )}
+                    <Button
+                        className="danger"
+                        type="button"
+                        data-testid={`remove-item-${index}`}
+                        onClick={() => handleRemove(index)}
+                    >
+                        <i className="fa-solid fa-minus" />
+                    </Button>
+                </li>
+            ))}
+            <li>
+                <Button
+                    type="button"
+                    data-testid="add-item"
+                    onClick={() => handleChange("", value.length)}
+                >
+                    <i className="fa-solid fa-plus" />
+                </Button>
+            </li>
+        </ol>
+    );
+};
+
+export default TextInputList;

--- a/src/components/ui/__tests__/TextInputList.test.js
+++ b/src/components/ui/__tests__/TextInputList.test.js
@@ -3,66 +3,122 @@ import TextInputList from "../TextInputList";
 import userEvent from "@testing-library/user-event";
 import { PromptProvider } from "../Prompt";
 
-describe('TextInputList', () => {
-    it('should render', () => {
+describe("TextInputList", () => {
+    it("should render", () => {
         render(<TextInputList data-testid="target" />);
         expect(screen.getByTestId("target")).toBeInTheDocument();
     });
 
-    it('should render with an initial array of strings', async () => {
-        const startValue = ['one', 'two', 'three'];
+    it("should render with an initial array of strings", async () => {
+        const startValue = ["one", "two", "three"];
         const changeHandler = jest.fn();
-        render(<PromptProvider><TextInputList data-testid="target" value={startValue} onChange={changeHandler} /></PromptProvider>);
+        render(
+            <PromptProvider>
+                <TextInputList
+                    data-testid="target"
+                    value={startValue}
+                    onChange={changeHandler}
+                />
+            </PromptProvider>,
+        );
 
-        expect(screen.getAllByRole('textbox')).toHaveLength(3);
-    })
-    it('should allow adding new values', async () => {
-        const startValue = ['one', 'two', 'three'];
+        expect(screen.getAllByRole("textbox")).toHaveLength(3);
+    });
+    it("should allow adding new values", async () => {
+        const startValue = ["one", "two", "three"];
         const changeHandler = jest.fn();
-        render(<PromptProvider><TextInputList data-testid="target" value={startValue} onChange={changeHandler} /></PromptProvider>);
+        render(
+            <PromptProvider>
+                <TextInputList
+                    data-testid="target"
+                    value={startValue}
+                    onChange={changeHandler}
+                />
+            </PromptProvider>,
+        );
 
         await userEvent.click(screen.getByTestId("add-item"));
-        expect(changeHandler).toHaveBeenCalledWith(['one', 'two', 'three', '']);
+        expect(changeHandler).toHaveBeenCalledWith(["one", "two", "three", ""]);
     });
-    it('should allow removing values', async () => {
-        const startValue = ['one', 'two', 'three'];
+    it("should allow removing values", async () => {
+        const startValue = ["one", "two", "three"];
         const changeHandler = jest.fn();
-        render(<PromptProvider><TextInputList data-testid="target" value={startValue} onChange={changeHandler} /></PromptProvider>);
+        render(
+            <PromptProvider>
+                <TextInputList
+                    data-testid="target"
+                    value={startValue}
+                    onChange={changeHandler}
+                />
+            </PromptProvider>,
+        );
 
         await userEvent.click(screen.getByTestId("remove-item-0"));
-        await userEvent.click(screen.getByTestId("prompt-submit"))
-        expect(changeHandler).toHaveBeenCalledWith(['two', 'three']);
+        await userEvent.click(screen.getByTestId("prompt-submit"));
+        expect(changeHandler).toHaveBeenCalledWith(["two", "three"]);
     });
-    it('should not confirm removal if the value is empty', async () => {
-        const startValue = ['', 'two', 'three'];
+    it("should not confirm removal if the value is empty", async () => {
+        const startValue = ["", "two", "three"];
         const changeHandler = jest.fn();
-        render(<PromptProvider><TextInputList data-testid="target" value={startValue} onChange={changeHandler} /></PromptProvider>);
+        render(
+            <PromptProvider>
+                <TextInputList
+                    data-testid="target"
+                    value={startValue}
+                    onChange={changeHandler}
+                />
+            </PromptProvider>,
+        );
 
         await userEvent.click(screen.getByTestId("remove-item-0"));
-        expect(changeHandler).toHaveBeenCalledWith(['two', 'three']);
-    })
-    it('should allow editing values', async () => {
-        const startValue = ['one', 'two', 'three'];
+        expect(changeHandler).toHaveBeenCalledWith(["two", "three"]);
+    });
+    it("should allow editing values", async () => {
+        const startValue = ["one", "two", "three"];
         const changeHandler = jest.fn();
-        render(<PromptProvider><TextInputList data-testid="target" value={startValue} onChange={changeHandler} /></PromptProvider>);
+        render(
+            <PromptProvider>
+                <TextInputList
+                    data-testid="target"
+                    value={startValue}
+                    onChange={changeHandler}
+                />
+            </PromptProvider>,
+        );
 
         await userEvent.type(screen.getByTestId("input-item-0"), "1");
-        expect(changeHandler).toHaveBeenCalledWith(['one1', 'two', 'three']);
+        expect(changeHandler).toHaveBeenCalledWith(["one1", "two", "three"]);
     });
-    it('should allow moving values up', async () => {
-        const startValue = ['one', 'two', 'three'];
+    it("should allow moving values up", async () => {
+        const startValue = ["one", "two", "three"];
         const changeHandler = jest.fn();
-        render(<PromptProvider><TextInputList data-testid="target" value={startValue} onChange={changeHandler} /></PromptProvider>);
+        render(
+            <PromptProvider>
+                <TextInputList
+                    data-testid="target"
+                    value={startValue}
+                    onChange={changeHandler}
+                />
+            </PromptProvider>,
+        );
 
         await userEvent.click(screen.getByTestId("move-up-item-1"));
-        expect(changeHandler).toHaveBeenCalledWith(['two', 'one', 'three']);
+        expect(changeHandler).toHaveBeenCalledWith(["two", "one", "three"]);
     });
-    it('should allow moving values down', async () => {
-        const startValue = ['one', 'two', 'three'];
+    it("should allow moving values down", async () => {
+        const startValue = ["one", "two", "three"];
         const changeHandler = jest.fn();
-        render(<PromptProvider><TextInputList data-testid="target" value={startValue} onChange={changeHandler} /></PromptProvider>);
+        render(
+            <PromptProvider>
+                <TextInputList
+                    data-testid="target"
+                    value={startValue}
+                    onChange={changeHandler}
+                />
+            </PromptProvider>,
+        );
 
         await userEvent.click(screen.getByTestId("move-down-item-1"));
-        expect(changeHandler).toHaveBeenCalledWith(['one', 'three', 'two']);
+        expect(changeHandler).toHaveBeenCalledWith(["one", "three", "two"]);
     });
 });

--- a/src/components/ui/__tests__/TextInputList.test.js
+++ b/src/components/ui/__tests__/TextInputList.test.js
@@ -1,0 +1,68 @@
+import { render, screen } from "@testing-library/react";
+import TextInputList from "../TextInputList";
+import userEvent from "@testing-library/user-event";
+import { PromptProvider } from "../Prompt";
+
+describe('TextInputList', () => {
+    it('should render', () => {
+        render(<TextInputList data-testid="target" />);
+        expect(screen.getByTestId("target")).toBeInTheDocument();
+    });
+
+    it('should render with an initial array of strings', async () => {
+        const startValue = ['one', 'two', 'three'];
+        const changeHandler = jest.fn();
+        render(<PromptProvider><TextInputList data-testid="target" value={startValue} onChange={changeHandler} /></PromptProvider>);
+
+        expect(screen.getAllByRole('textbox')).toHaveLength(3);
+    })
+    it('should allow adding new values', async () => {
+        const startValue = ['one', 'two', 'three'];
+        const changeHandler = jest.fn();
+        render(<PromptProvider><TextInputList data-testid="target" value={startValue} onChange={changeHandler} /></PromptProvider>);
+
+        await userEvent.click(screen.getByTestId("add-item"));
+        expect(changeHandler).toHaveBeenCalledWith(['one', 'two', 'three', '']);
+    });
+    it('should allow removing values', async () => {
+        const startValue = ['one', 'two', 'three'];
+        const changeHandler = jest.fn();
+        render(<PromptProvider><TextInputList data-testid="target" value={startValue} onChange={changeHandler} /></PromptProvider>);
+
+        await userEvent.click(screen.getByTestId("remove-item-0"));
+        await userEvent.click(screen.getByTestId("prompt-submit"))
+        expect(changeHandler).toHaveBeenCalledWith(['two', 'three']);
+    });
+    it('should not confirm removal if the value is empty', async () => {
+        const startValue = ['', 'two', 'three'];
+        const changeHandler = jest.fn();
+        render(<PromptProvider><TextInputList data-testid="target" value={startValue} onChange={changeHandler} /></PromptProvider>);
+
+        await userEvent.click(screen.getByTestId("remove-item-0"));
+        expect(changeHandler).toHaveBeenCalledWith(['two', 'three']);
+    })
+    it('should allow editing values', async () => {
+        const startValue = ['one', 'two', 'three'];
+        const changeHandler = jest.fn();
+        render(<PromptProvider><TextInputList data-testid="target" value={startValue} onChange={changeHandler} /></PromptProvider>);
+
+        await userEvent.type(screen.getByTestId("input-item-0"), "1");
+        expect(changeHandler).toHaveBeenCalledWith(['one1', 'two', 'three']);
+    });
+    it('should allow moving values up', async () => {
+        const startValue = ['one', 'two', 'three'];
+        const changeHandler = jest.fn();
+        render(<PromptProvider><TextInputList data-testid="target" value={startValue} onChange={changeHandler} /></PromptProvider>);
+
+        await userEvent.click(screen.getByTestId("move-up-item-1"));
+        expect(changeHandler).toHaveBeenCalledWith(['two', 'one', 'three']);
+    });
+    it('should allow moving values down', async () => {
+        const startValue = ['one', 'two', 'three'];
+        const changeHandler = jest.fn();
+        render(<PromptProvider><TextInputList data-testid="target" value={startValue} onChange={changeHandler} /></PromptProvider>);
+
+        await userEvent.click(screen.getByTestId("move-down-item-1"));
+        expect(changeHandler).toHaveBeenCalledWith(['one', 'three', 'two']);
+    });
+});


### PR DESCRIPTION
Adds music as a first class field that users and editors can see and edit.

- Adds music as a column in activities, expecting an array of strings
- Adds music field support for APIs
- Adds music display in activities, only visible to users/editors
- Displays red when music is missing
- Adds music management to editing/creating an activity
- Adds music management to directly to activities