### PR TITLE
Allow easier music library clean up with multi-delete

### DIFF
--- a/src/components/EventListItem.js
+++ b/src/components/EventListItem.js
@@ -22,13 +22,9 @@ const EventListItem = ({ event, onDelete = () => {}, onEdit = () => {} }) => {
             `Are you sure you want to delete "${event.name}"? This will also delete all activities and comments associated with it.`,
             "confirm",
         );
-
         setPending(true);
-
         await deleteEventApi(event.id);
-
         setPending(false);
-
         onDelete(event.id);
     }
     return (

--- a/src/components/MusicLibraryActions.js
+++ b/src/components/MusicLibraryActions.js
@@ -4,12 +4,16 @@ import { css } from "../../styled-system/css";
 import Button from "./ui/Button";
 import { usePrompt } from "./ui/Prompt";
 
-const MusicLibraryActions = ({ music, ...props }) => {
+const MusicLibraryActions = ({ music, pending = false, ...props }) => {
     const { openPrompt } = usePrompt();
     const { deleteMusic, updateMusic } = useMusicLibrary();
-    const [isLoading, setIsLoading] = useState(false);
+    const [isLoading, setIsLoading] = useState(pending);
 
     async function handleDelete() {
+        await openPrompt(
+            `Are you sure you want to delete an item from the music library?`,
+            "confirm",
+        );
         setIsLoading(true);
         await deleteMusic([music.id]);
         setIsLoading(false);

--- a/src/components/MusicLibraryList.js
+++ b/src/components/MusicLibraryList.js
@@ -12,9 +12,9 @@ import { usePrompt } from "./ui/Prompt";
 
 const MusicLibraryList = ({ ...props }) => {
     const { musicLibrary, deleteMusic } = useMusicLibrary();
-    const [ pending, setPending ] = useState(false);
+    const [pending, setPending] = useState(false);
     const { isEditor } = useAuth();
-    const [ selectedMusic, setSelectedMusic ] = useState([]);
+    const [selectedMusic, setSelectedMusic] = useState([]);
     const { openPrompt } = usePrompt();
 
     const [searchTerm, setSearchTerm] = useState("");
@@ -71,7 +71,9 @@ const MusicLibraryList = ({ ...props }) => {
                         disabled={!selectedMusic.length || pending}
                         onClick={deleteSelectedMusic}
                     >
-                        <i className="fa-solid fa-trash"></i> Delete {selectedMusic.length} item{selectedMusic.length === 1 ? "" : "s"} 
+                        <i className="fa-solid fa-trash"></i> Delete{" "}
+                        {selectedMusic.length} item
+                        {selectedMusic.length === 1 ? "" : "s"}
                     </Button>
                 </div>
             )}
@@ -80,13 +82,24 @@ const MusicLibraryList = ({ ...props }) => {
                     <Tr>
                         {isEditor() && (
                             <Th className={css({ width: "35px" })}>
-                                <Checkbox 
+                                <Checkbox
                                     data-testid="select-all"
-                                    indeterminate = {selectedMusic.length > 0 && selectedMusic.length < musicLibrary.length}
-                                    checked = {selectedMusic.length === musicLibrary.length}
+                                    indeterminate={
+                                        selectedMusic.length > 0 &&
+                                        selectedMusic.length <
+                                            musicLibrary.length
+                                    }
+                                    checked={
+                                        selectedMusic.length ===
+                                        musicLibrary.length
+                                    }
                                     onChange={(e) => {
                                         if (e.target.checked) {
-                                            setSelectedMusic(musicLibrary.map((music) => music.id));
+                                            setSelectedMusic(
+                                                musicLibrary.map(
+                                                    (music) => music.id,
+                                                ),
+                                            );
                                         } else {
                                             setSelectedMusic([]);
                                         }
@@ -115,12 +128,21 @@ const MusicLibraryList = ({ ...props }) => {
                                 <Td className={css({ width: "35px" })}>
                                     <Checkbox
                                         data-testid="select-music"
-                                        checked={selectedMusic.includes(music.id)}
+                                        checked={selectedMusic.includes(
+                                            music.id,
+                                        )}
                                         onChange={(e) => {
                                             if (e.target.checked) {
-                                                setSelectedMusic([...selectedMusic, music.id]);
+                                                setSelectedMusic([
+                                                    ...selectedMusic,
+                                                    music.id,
+                                                ]);
                                             } else {
-                                                setSelectedMusic(selectedMusic.filter((id) => id !== music.id));
+                                                setSelectedMusic(
+                                                    selectedMusic.filter(
+                                                        (id) => id !== music.id,
+                                                    ),
+                                                );
                                             }
                                         }}
                                     />
@@ -132,7 +154,10 @@ const MusicLibraryList = ({ ...props }) => {
                                     className={css({ width: "140px" })}
                                     data-testid="actions"
                                 >
-                                    <MusicLibraryActions music={music} pending={pending} />
+                                    <MusicLibraryActions
+                                        music={music}
+                                        pending={pending}
+                                    />
                                 </Td>
                             )}
                         </Tr>

--- a/src/components/MusicLibraryList.js
+++ b/src/components/MusicLibraryList.js
@@ -7,10 +7,15 @@ import { Table, Tbody, Td, Th, Thead, Tr } from "./ui/Table";
 import TextInput from "./ui/TextInput";
 import { css } from "../../styled-system/css";
 import H1 from "./ui/H1";
+import Checkbox from "./ui/Checkbox";
+import { usePrompt } from "./ui/Prompt";
 
 const MusicLibraryList = ({ ...props }) => {
-    const { musicLibrary } = useMusicLibrary();
+    const { musicLibrary, deleteMusic } = useMusicLibrary();
+    const [ pending, setPending ] = useState(false);
     const { isEditor } = useAuth();
+    const [ selectedMusic, setSelectedMusic ] = useState([]);
+    const { openPrompt } = usePrompt();
 
     const [searchTerm, setSearchTerm] = useState("");
     const filteredMusicLibrary = useMemo(() => {
@@ -21,6 +26,17 @@ const MusicLibraryList = ({ ...props }) => {
             music.value.toLowerCase().includes(searchTerm.toLowerCase()),
         );
     }, [searchTerm, musicLibrary]);
+
+    async function deleteSelectedMusic() {
+        await openPrompt(
+            `Are you sure you want to delete ${selectedMusic.length} item${selectedMusic.length > 0 ? "s" : ""} from the music library?`,
+            "confirm",
+        );
+        setPending(true);
+        await deleteMusic(selectedMusic);
+        setSelectedMusic([]);
+        setPending(false);
+    }
 
     return (
         <div {...props}>
@@ -46,9 +62,38 @@ const MusicLibraryList = ({ ...props }) => {
                     <i className="fa-solid fa-xmark"></i>
                 </Button>
             </div>
+            {isEditor() && (
+                <div className={css({ display: "flex", gap: "8px" })}>
+                    <Button
+                        title={`Delete ${selectedMusic.length} items`}
+                        className="danger"
+                        data-testid="delete-multiple"
+                        disabled={!selectedMusic.length || pending}
+                        onClick={deleteSelectedMusic}
+                    >
+                        <i className="fa-solid fa-trash"></i> Delete {selectedMusic.length} item{selectedMusic.length === 1 ? "" : "s"} 
+                    </Button>
+                </div>
+            )}
             <Table>
                 <Thead>
                     <Tr>
+                        {isEditor() && (
+                            <Th className={css({ width: "35px" })}>
+                                <Checkbox 
+                                    data-testid="select-all"
+                                    indeterminate = {selectedMusic.length > 0 && selectedMusic.length < musicLibrary.length}
+                                    checked = {selectedMusic.length === musicLibrary.length}
+                                    onChange={(e) => {
+                                        if (e.target.checked) {
+                                            setSelectedMusic(musicLibrary.map((music) => music.id));
+                                        } else {
+                                            setSelectedMusic([]);
+                                        }
+                                    }}
+                                />
+                            </Th>
+                        )}
                         <Th>Music</Th>
                         {isEditor() && (
                             <Th
@@ -66,13 +111,28 @@ const MusicLibraryList = ({ ...props }) => {
                     )}
                     {filteredMusicLibrary.map((music) => (
                         <Tr key={music.id}>
+                            {isEditor() && (
+                                <Td className={css({ width: "35px" })}>
+                                    <Checkbox
+                                        data-testid="select-music"
+                                        checked={selectedMusic.includes(music.id)}
+                                        onChange={(e) => {
+                                            if (e.target.checked) {
+                                                setSelectedMusic([...selectedMusic, music.id]);
+                                            } else {
+                                                setSelectedMusic(selectedMusic.filter((id) => id !== music.id));
+                                            }
+                                        }}
+                                    />
+                                </Td>
+                            )}
                             <Td>{music.value}</Td>
                             {isEditor() && (
                                 <Td
                                     className={css({ width: "140px" })}
                                     data-testid="actions"
                                 >
-                                    <MusicLibraryActions music={music} />
+                                    <MusicLibraryActions music={music} pending={pending} />
                                 </Td>
                             )}
                         </Tr>

--- a/src/components/__tests__/MusicLibraryActions.test.js
+++ b/src/components/__tests__/MusicLibraryActions.test.js
@@ -38,6 +38,7 @@ describe("MusicLibraryActions", () => {
         );
 
         await userEvent.click(screen.getByTitle("Delete"));
+        await userEvent.click(screen.getByTestId("prompt-submit"));
 
         expect(mockDelete).toHaveBeenCalledWith([mockMusic.id]);
     });

--- a/src/components/__tests__/MusicLibraryList.test.js
+++ b/src/components/__tests__/MusicLibraryList.test.js
@@ -88,11 +88,15 @@ describe("MusicLibraryList", () => {
         await userEvent.click(screen.getByTestId("clear-search"));
         expect(screen.getAllByRole("row")).toHaveLength(4);
     });
-    it('allows an editor to delete multiple music items', async () => {
+    it("allows an editor to delete multiple music items", async () => {
         useAuth.mockReturnValue({
             isEditor: () => true,
         });
-        render(<PromptProvider><MusicLibraryList /></PromptProvider>);
+        render(
+            <PromptProvider>
+                <MusicLibraryList />
+            </PromptProvider>,
+        );
 
         const checkboxes = screen.getAllByTestId("select-music");
         await userEvent.click(checkboxes[0]);
@@ -102,11 +106,15 @@ describe("MusicLibraryList", () => {
 
         expect(mockDeleteMusic).toHaveBeenCalledWith(["A", "B"]);
     });
-    it('allows an editor to delete all music items', async () => {
+    it("allows an editor to delete all music items", async () => {
         useAuth.mockReturnValue({
             isEditor: () => true,
         });
-        render(<PromptProvider><MusicLibraryList /></PromptProvider>);
+        render(
+            <PromptProvider>
+                <MusicLibraryList />
+            </PromptProvider>,
+        );
 
         await userEvent.click(screen.getByTestId("select-all"));
         await userEvent.click(screen.getByTestId("delete-multiple"));

--- a/src/components/__tests__/MusicLibraryList.test.js
+++ b/src/components/__tests__/MusicLibraryList.test.js
@@ -3,18 +3,22 @@ import MusicLibraryList from "../MusicLibraryList";
 import { useMusicLibrary } from "../MusicLibraryContainer";
 import { useAuth } from "../global/Auth";
 import userEvent from "@testing-library/user-event";
+import { PromptProvider } from "../ui/Prompt";
 
 jest.mock("../MusicLibraryContainer");
 jest.mock("../global/Auth");
 
 describe("MusicLibraryList", () => {
+    let mockDeleteMusic;
     beforeEach(() => {
+        mockDeleteMusic = jest.fn().mockResolvedValue();
         useMusicLibrary.mockReturnValue({
             musicLibrary: [
                 { value: "a", id: "A" },
                 { value: "b", id: "B" },
                 { value: "c", id: "C" },
             ],
+            deleteMusic: mockDeleteMusic,
         });
         useAuth.mockReturnValue({
             isEditor: () => true,
@@ -83,5 +87,31 @@ describe("MusicLibraryList", () => {
 
         await userEvent.click(screen.getByTestId("clear-search"));
         expect(screen.getAllByRole("row")).toHaveLength(4);
+    });
+    it('allows an editor to delete multiple music items', async () => {
+        useAuth.mockReturnValue({
+            isEditor: () => true,
+        });
+        render(<PromptProvider><MusicLibraryList /></PromptProvider>);
+
+        const checkboxes = screen.getAllByTestId("select-music");
+        await userEvent.click(checkboxes[0]);
+        await userEvent.click(checkboxes[1]);
+        await userEvent.click(screen.getByTestId("delete-multiple"));
+        await userEvent.click(screen.getByTestId("prompt-submit"));
+
+        expect(mockDeleteMusic).toHaveBeenCalledWith(["A", "B"]);
+    });
+    it('allows an editor to delete all music items', async () => {
+        useAuth.mockReturnValue({
+            isEditor: () => true,
+        });
+        render(<PromptProvider><MusicLibraryList /></PromptProvider>);
+
+        await userEvent.click(screen.getByTestId("select-all"));
+        await userEvent.click(screen.getByTestId("delete-multiple"));
+        await userEvent.click(screen.getByTestId("prompt-submit"));
+
+        expect(mockDeleteMusic).toHaveBeenCalledWith(["A", "B", "C"]);
     });
 });

--- a/src/components/ui/Checkbox.js
+++ b/src/components/ui/Checkbox.js
@@ -1,0 +1,30 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * A checkbox component that can be used to toggle a boolean value.
+ *
+ * @param {string} [className] The CSS class name to apply to the checkbox.
+ * @param {boolean} checked Whether the checkbox is checked.
+ * @param {boolean} indeterminate Whether the checkbox is in an indeterminate state.
+ * @param {function} onChange Called when the checkbox is changed.
+ */
+const Checkbox = ({ className = "", checked, indeterminate, onChange, ...props }) => {
+
+    const checkboxRef = useRef(null);
+    useEffect(() => {
+        checkboxRef.current.indeterminate = indeterminate;
+    }, [checkboxRef, indeterminate]);
+
+    return (
+        <input
+            {...props}
+            ref={checkboxRef}
+            type="checkbox"
+            className={className}
+            checked={checked}
+            onChange={onChange}
+        />
+    )
+}
+
+export default Checkbox;

--- a/src/components/ui/Checkbox.js
+++ b/src/components/ui/Checkbox.js
@@ -8,8 +8,13 @@ import { useEffect, useRef } from "react";
  * @param {boolean} indeterminate Whether the checkbox is in an indeterminate state.
  * @param {function} onChange Called when the checkbox is changed.
  */
-const Checkbox = ({ className = "", checked, indeterminate, onChange, ...props }) => {
-
+const Checkbox = ({
+    className = "",
+    checked,
+    indeterminate,
+    onChange,
+    ...props
+}) => {
     const checkboxRef = useRef(null);
     useEffect(() => {
         checkboxRef.current.indeterminate = indeterminate;
@@ -24,7 +29,7 @@ const Checkbox = ({ className = "", checked, indeterminate, onChange, ...props }
             checked={checked}
             onChange={onChange}
         />
-    )
-}
+    );
+};
 
 export default Checkbox;


### PR DESCRIPTION
- Created a checkbox-selection UI on the music library list that editors can see to see.
- Created a delete button to delete selected music library items
- Added confirmation prompt to normal music entry deletion